### PR TITLE
treewide: add SPDX-License-Identifier and SPDX-FileCopyrightText to all source files without explicit license information

### DIFF
--- a/sources/can.c
+++ b/sources/can.c
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2018, 2020 Eric Evenchick <eric@evenchick.com>
 // SPDX-License-Identifier: MIT
 /*
  * can.c

--- a/sources/can.c
+++ b/sources/can.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
  * can.c
  *

--- a/sources/can.h
+++ b/sources/can.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
  * can.h
  *

--- a/sources/can.h
+++ b/sources/can.h
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2018, 2020 Eric Evenchick <eric@evenchick.com>
 // SPDX-License-Identifier: MIT
 /*
  * can.h

--- a/sources/gpio.c
+++ b/sources/gpio.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
  * gpio.c
  *

--- a/sources/gpio.c
+++ b/sources/gpio.c
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2019, 2020 Eric Evenchick <eric@evenchick.com>
 // SPDX-License-Identifier: MIT
 /*
  * gpio.c

--- a/sources/gpio.h
+++ b/sources/gpio.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
  * gpio.h
  *

--- a/sources/gpio.h
+++ b/sources/gpio.h
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2019, 2020 Eric Evenchick <eric@evenchick.com>
 // SPDX-License-Identifier: MIT
 /*
  * gpio.h

--- a/usb/device/class/gs_usb/gs_usb.h
+++ b/usb/device/class/gs_usb/gs_usb.h
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2018, 2020 Eric Evenchick <eric@evenchick.com>
 // SPDX-License-Identifier: MIT
 /*
  * gs_usb.h

--- a/usb/device/class/gs_usb/gs_usb.h
+++ b/usb/device/class/gs_usb/gs_usb.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
  * gs_usb.h
  */

--- a/usb/device/class/gs_usb/gs_usb_class.c
+++ b/usb/device/class/gs_usb/gs_usb_class.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
  * gs_usb_class.c
  *

--- a/usb/device/class/gs_usb/gs_usb_class.c
+++ b/usb/device/class/gs_usb/gs_usb_class.c
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2018, 2019, 2020 Eric Evenchick <eric@evenchick.com>
 // SPDX-License-Identifier: MIT
 /*
  * gs_usb_class.c

--- a/usb/device/class/gs_usb/gs_usb_class.h
+++ b/usb/device/class/gs_usb/gs_usb_class.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*
  * gs_usb_class.h
  *

--- a/usb/device/class/gs_usb/gs_usb_class.h
+++ b/usb/device/class/gs_usb/gs_usb_class.h
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2018 Eric Evenchick <eric@evenchick.com>
 // SPDX-License-Identifier: MIT
 /*
  * gs_usb_class.h


### PR DESCRIPTION
In preparation for a request for a USB PID via https://github.com/openmoko/openmoko-usb-oui/pull/39.